### PR TITLE
Fix disable control workaround not working after from Angular 15

### DIFF
--- a/projects/smpl-select2/src/lib/smpl-select2.directive.ts
+++ b/projects/smpl-select2/src/lib/smpl-select2.directive.ts
@@ -49,7 +49,7 @@ export class SmplSelect2Directive implements ControlValueAccessor, OnInit, OnCha
   }
   private _value: any;
 
-  private _disabled: boolean;
+  private _disabled: boolean = true;
 
   private _onChanged: any = () => { };
   private _onTouched: any = () => { };
@@ -123,7 +123,10 @@ export class SmplSelect2Directive implements ControlValueAccessor, OnInit, OnCha
   }
 
   setDisabledState(isDisabled: boolean): void {
-    // override isDisabled false when data is not set
+    // Scrolling bug: Select2 has dynamic datasource. Select2 container is a scrollable element other than body.
+    //                Open select2 when data is empty, stay there until data is set.
+    //                Close selection panel. The container is unable to scroll.
+    // Workaround: Disable select2 to prevent opening selection panel before data is set.
     if (!this.dataSource?.data?.length && !this.dataSource?.ajaxFn) {
       isDisabled = true;
     }
@@ -244,16 +247,7 @@ export class SmplSelect2Directive implements ControlValueAccessor, OnInit, OnCha
   }
 
   private _setupDataSource(): void {
-
-    // Scrolling bug: Select2 has dynamic datasource. Select2 container is a scrollable element other than body.
-    //                Open select2 when data is empty, stay there until data is set.
-    //                Close selection panel. The container is unable to scroll.
-    // Workaround: Disable select2 to prevent opening selection panel before data is set.
-    if (!this.dataSource?.data?.length && !this.dataSource?.ajaxFn) {
-      this.setDisabledState(true);
-    } else {
-      this.setDisabledState(false);
-    }
+    this.setDisabledState(false);
 
     this.dataSource = this.dataSource || {};
 
@@ -332,6 +326,7 @@ export class SmplSelect2Directive implements ControlValueAccessor, OnInit, OnCha
       $element.select2('destroy');
     }
 
+    options.disabled = this._disabled;
     $element.select2(options);
   }
 

--- a/projects/smpl-select2/src/lib/smpl-select2.directive.ts
+++ b/projects/smpl-select2/src/lib/smpl-select2.directive.ts
@@ -123,6 +123,11 @@ export class SmplSelect2Directive implements ControlValueAccessor, OnInit, OnCha
   }
 
   setDisabledState(isDisabled: boolean): void {
+    // override isDisabled false when data is not set
+    if (!this.dataSource?.data?.length && !this.dataSource?.ajaxFn) {
+      isDisabled = true;
+    }
+
     this._disabled = isDisabled;
 
     const $element = $(this._el.nativeElement);


### PR DESCRIPTION
When we associate select2 with a reactive form control, 
`setDisabledState` is called right after we initialize the form control. 

If we don't specify the disable state of the form control at the time of intialization, `setDisabledState` will be called with `false` value, which overrides the disabled state we set in line 248

```typescript
if (!this.dataSource?.data?.length && !this.dataSource?.ajaxFn) {
      this.setDisabledState(true);
}
```

This PR override that behavior by checking the same condition in `setDisabledState`