### PR TITLE
Prevent select2:open event when clearing selection

### DIFF
--- a/projects/smpl-select2/src/lib/smpl-select2.directive.ts
+++ b/projects/smpl-select2/src/lib/smpl-select2.directive.ts
@@ -171,6 +171,17 @@ export class SmplSelect2Directive implements ControlValueAccessor, OnInit, OnCha
         e.preventDefault();
       }
     });
+
+    // completely prevent default behavior of clear event on closeOnClear
+    $(this._el.nativeElement).on("select2:clear", (e) => {
+      if (this.configOptions.closeOnClear) {
+        $(this._el.nativeElement).on("select2:opening", (evt) => {
+          evt.preventDefault();
+          
+          $(this._el.nativeElement).off("select2:opening");
+        });
+      }
+    });
   }
 
   private _registerSelectEvent(): void {

--- a/projects/smpl-select2/src/lib/smpl-select2.model.ts
+++ b/projects/smpl-select2/src/lib/smpl-select2.model.ts
@@ -8,6 +8,7 @@ export interface Select2Config {
   multiple?: boolean;
   selectOnClose?: boolean;
   closeOnSelect?: boolean;
+  closeOnClear?: boolean;
 
   maximumInputLength?: number;
   maximumSelectionLength?: number;


### PR DESCRIPTION
Issue:
- Select2:open event is trigged when clearing selection
Reference: https://github.com/select2/select2/issues/3320

In select2 source:
- `AllowClear` function auto trigger `toggleDropdown` event

Solution:
- Manage dropdown toggle by `closeOnClear` prop

closeOnClear = false ( default )
![firefox_399xvHBggK](https://user-images.githubusercontent.com/87089026/233696408-6d4d60f1-9365-4691-9b7c-0e26230d8e44.gif)

closeOnClear = true
![firefox_ebV1ljo8OZ](https://user-images.githubusercontent.com/87089026/233696534-6941f353-4c39-44e9-bf2c-9186e53ab8bf.gif)
