### PR TITLE
intialize select2 with configOptions disabled property

### DIFF
--- a/projects/smpl-select2/src/lib/smpl-select2.directive.ts
+++ b/projects/smpl-select2/src/lib/smpl-select2.directive.ts
@@ -327,7 +327,7 @@ export class SmplSelect2Directive implements ControlValueAccessor, OnInit, OnCha
     // select2 has been initialized
     this._closeAndDestroySelect2(this._el.nativeElement);
 
-    options.disabled = this._disabled;
+    options.disabled = this._disabled || this.configOptions.disabled;
     $element.select2(options);
   }
 


### PR DESCRIPTION
Previous PR overrode `configOptions.disabled` property.

So any component templates are using 
```
<select2 [smplSelect2]="{ disabled: mainForm.disabled }">
```
Are all affected and unable to disable correctly (Control looks disabled but able to select normally)